### PR TITLE
Add framework for terrain painting

### DIFF
--- a/example.hexmap
+++ b/example.hexmap
@@ -1,6 +1,6 @@
 0,0 {
-	terrain: mountain,
-	label: "Mountain",
+	terrain: plains,
+	biome: temperate,
 	features: [
 		village, // the first feature is placed in the center of the hex
 		lair // subsequent features are offset by a random value within the hex (seeded by the axial coords)
@@ -9,36 +9,33 @@
 	roads: [1->3, 2->3, 3->5,village->lair, lair->1, lair->0]
 }
 1,0 {
-	terrain: hills,
-	label: "Hills",
-	features: [lair, village],
-	roads: [5->0]
-}
+	terrain: waves,
+	biome: ocean,
 0,-1 {
 	terrain: hills,
+	biome: arctic,
 	label: "Hills",
 	features: [city, village, hamlet],
 	roads: [4->2,0->4, 1->city,city->village, city->hamlet, hamlet->village, hamlet->3]
 }
 0,1 {
 	terrain: hills,
-	label: "Hills",
+	biome: tropical,
 	features: [lair, village],
 	roads: [0->5, village->lair, village->0, lair->0]
 }
 -1,0 {
+	biome: tundra,
 	terrain: hills,
-	label: "Hills",
 	roads: [2->1, 2->3]
 }
 1,-1 {
-	terrain: hills,
-	label: "Hills",
-	roads: [3->4,3->5]
+	biome: ocean,
+	terrain: waves,
 }
 -1,1 {
+	biome: arid,
 	terrain: hills,
-	label: "Hills",
 	roads: [0->2]
 }
 

--- a/hex-drawing.el
+++ b/hex-drawing.el
@@ -26,9 +26,9 @@ Runs \(random t) at the end to avoid reproducible numbers elsewhere."
 (defun hex-draw (svg x y size &optional fill stroke label)
   "Draw a hex in SVG with center of X, Y and specified SIZE.
 Optionally provide the FILL, STROKE, and LABEL for the hex."
-  (let ((fill (or fill "pink"))
+  (let ((fill (or fill "transparent"))
 	(label (or label ""))
-	(stroke (or stroke "transparent")))
+	(stroke (or stroke "black")))
     (svg-polygon svg (hexes-flat-corners x y size)
 		 :stroke-color stroke :fill-color fill)
     (svg-text svg label :x x :y y :font-size (/ size 2) :text-anchor "middle")))

--- a/hex-drawing.el
+++ b/hex-drawing.el
@@ -94,6 +94,34 @@ and incrementing by one going clockwise."
   "A list of functions for features and how they should be drawn."
   :group 'hexmapping)
 
+(defun hex-draw-terrain--draw-blank (svg x y size &optional terrain)
+  "Draw no TERRAIN on SVG at X, Y with given SIZE.
+This function does nothing on purpose and just takes the appropriate input."
+  (message "Terrain: %s does not have a draw-function" terrain))
+
+(defun hex-draw-terrain--draw-hills (svg x y size &optional biome)
+  "Draw a hill terrain symbol on SVG at X,Y at given SIZE.
+Provide BIOME to get the matching `biome-highlight-colours'."
+  (let ((xr (* x (/ 35.0 200)))
+	(yr (* y (/ 100.0 200)))
+	(colour (if biome (cdr (assoc biome biome-highlight-colours)) "white")))
+    (svg-path svg `((moveto ((,x . ,y)))
+		    (elliptical-arc ((,(* size (/ 35.0 80)) ,(* size (/ 100.0 80)) ,(* size (/ 40.0 80)) 0 :sweep t))))
+	      :fill "transparent" :stroke colour :relative t :stroke-width (* size (/ 4.0 80)))
+    (svg-path svg `((moveto ((,x . ,y)))
+		    (moveto ((,(* size (/ -20.0 80)) . ,(* size (/ -20.0 80)))) :relative t)
+		    (elliptical-arc ((,(* size (/ 35.0 80)) ,(* size (/ 100.0 80)) ,(* size (/ 40.0 80)) 0 :sweep t))))
+	      :fill "transparent" :stroke colour :relative t :stroke-width (* size (/ 4.0 80)))
+    (svg-path svg `((moveto ((,x . ,y)))
+		    (moveto ((,(* size (/ -50.0 80)) . 0)) :relative t)
+		    (elliptical-arc ((,(* size (/ 35.0 80)) ,(* size (/ 100.0 80)) ,(* size (/ 40.0 80))
+				      ,(* size (/ -5.0 80)) :sweep t))))
+	      :fill "transparent" :stroke colour :relative t :stroke-width (* size (/ 4.0 80)))))
+
+(defcustom terrain-draw-functions '((hills . hex-draw-terrain--draw-hills)
+				    (nil . hex-draw-terrain--draw-blank))
+  "A list of functions for terrains and how they should be drawn."
+  :group 'hexmapping)
 (defun hex-draw-feature (svg x y size label &optional feature)
   "Draw a specified FEATURE on the SVG at X and Y with SIZE."
   (let ((func (cdr (assoc feature feature-draw-functions)))

--- a/hex-drawing.el
+++ b/hex-drawing.el
@@ -89,10 +89,6 @@ and incrementing by one going clockwise."
 		 (/ size 5) (/ size 5) :stroke-color "black" :stroke-width (* size (/ 3.0 80.0)))
   (svg-text svg label :x x :y (- y (/ size 5)) :font-size (/ size 6) :text-anchor "middle"))
 
-
-(defgroup hexmapping nil
-  "Specifying hexmaps for ttrpgs.")
-
 (defcustom feature-draw-functions '((village . hex-draw-feature--draw-village)
 				    (nil . hex-draw-feature--draw-unknown))
   "A list of functions for features and how they should be drawn."

--- a/hex-drawing.el
+++ b/hex-drawing.el
@@ -122,6 +122,24 @@ Provide BIOME to get the matching `biome-highlight-colours'."
 				    (nil . hex-draw-terrain--draw-blank))
   "A list of functions for terrains and how they should be drawn."
   :group 'hexmapping)
+
+(defun hex-draw-terrain (svg x y size &optional terrain biome)
+  "Draw a specified TERRAIN on the SVG at X and Y with SIZE."
+  (let ((func (cdr (assoc terrain terrain-draw-functions)))
+	(unknown-func (cdr (assoc 'nil terrain-draw-functions))))
+    (if func
+	(apply func `(,svg ,x, y, size, biome))
+      (apply unknown-func `(,svg ,x ,y ,size ,terrain)))))
+
+(defun hex-draw-terrain-axial (svg q r size &optional canvas terrain biome)
+  "Draw a specified TERRAIN on the SVG at Q and R with SIZE.
+CANVAS is the size of the svg image, TERRAIN is the terrain to paint,
+and biome determines the highlight colour, see `hex-draw-terrain'."
+  (let ((hex-coords (hexes-axial-to-cartesian q r size (/ canvas 2))))
+	(hex-draw-terrain svg (car hex-coords) (cdr hex-coords) size
+			  terrain biome)))
+
+
 (defun hex-draw-feature (svg x y size label &optional feature)
   "Draw a specified FEATURE on the SVG at X and Y with SIZE."
   (let ((func (cdr (assoc feature feature-draw-functions)))

--- a/hexmap-mode.el
+++ b/hexmap-mode.el
@@ -151,6 +151,13 @@ Optionally set RIVERS to non-nil to parse rivers instead."
 			      800
 			      (cdr (assoc (plist-get hex :biome) biome-colours))
 			      "black")
+	      ;; function to draw terrain
+	      (hex-draw-terrain-axial svg
+				      (car (plist-get hex :axial-coords))
+				      (cdr (plist-get hex :axial-coords))
+				      size 800
+				      (plist-get hex :terrain)
+				      (plist-get hex :biome))
 	      ;; function to draw roads here
 	      (mapc #'(lambda (road)
 			(let ((start (if (symbolp (car road))

--- a/hexmap-mode.el
+++ b/hexmap-mode.el
@@ -138,8 +138,8 @@ Optionally set RIVERS to non-nil to parse rivers instead."
 			      (cdr (plist-get hex :axial-coords))
 			      size
 			      800
-			      "green"
-			      "transparent")
+			      (cdr (assoc (plist-get hex :biome) biome-colours))
+			      "black")
 	      ;; function to draw roads here
 	      (mapc #'(lambda (road)
 			(let ((start (if (symbolp (car road))

--- a/hexmap-mode.el
+++ b/hexmap-mode.el
@@ -29,6 +29,17 @@
   :group 'hexmapping)
 
 
+(defcustom biome-highlight-colours '((arctic . "gray")
+				     (temperate . "darkgreen")
+				     (tundra . "green")
+				     (arid . "#b3b300")
+				     (tropical . "#004235")
+				     (ocean . "lightblue")
+				     (lake . "darkblue")
+				     (nil . "black"))
+  "A list of hex colours to be used for different biomes."
+  :group 'hexmapping)
+
 (defun hexmap-mark-hex-at-point ()
   "Mark the hex specification at point."
   (interactive)

--- a/hexmap-mode.el
+++ b/hexmap-mode.el
@@ -14,6 +14,21 @@
 
 (require 'hex-drawing)
 
+(defgroup hexmapping nil
+  "Specifying hexmaps for ttrpgs.")
+
+(defcustom biome-colours '((arctic . "white")
+			   (temperate . "green")
+			   (tundra . "darkgreen")
+			   (arid . "yellow")
+			   (tropical . "#00755e")
+			   (ocean . "blue")
+			   (lake . "lightblue")
+			   (nil . "pink"))
+  "A list of hex colours to be used for different biomes."
+  :group 'hexmapping)
+
+
 (defun hexmap-mark-hex-at-point ()
   "Mark the hex specification at point."
   (interactive)

--- a/hexmap-mode.el
+++ b/hexmap-mode.el
@@ -82,10 +82,14 @@ Optionally set RIVERS to non-nil to parse rivers instead."
     (let ((axial-coords (hexmap--extract-axial-coords hex))
 	  (terrain (hexmap--extract-keyword hex "terrain"))
 	  (label (replace-regexp-in-string "\"" "" (hexmap--extract-keyword hex "label")))
+	  (biome (hexmap--extract-keyword hex "biome"))
 	  (features (hexmap--extract-keyword hex "features" t))
 	  (roads (hexmap--extract-roads hex))
 	  (rivers (hexmap--extract-roads hex t)))
-      `(:axial-coords ,axial-coords :terrain ,(intern terrain) :label ,label
+      `(:axial-coords ,axial-coords
+		      :biome ,(intern biome)
+		      :terrain ,(intern terrain)
+		      :label ,label
 		      :features ,(mapcar #'intern features)
 		      :roads ,roads
 		      :rivers ,rivers))))
@@ -209,6 +213,7 @@ Optionally set RIVERS to non-nil to parse rivers instead."
   ;; Syntax highlighting
   (font-lock-add-keywords nil
 			  '(("terrain:" . font-lock-doc-face)
+			    ("biome:" . font-lock-doc-face)
 			    ("rivers:" . font-lock-doc-face)
 			    ("label:" . font-lock-string-face)
 			    ("features:" . font-lock-type-face)

--- a/hexmap-mode.el
+++ b/hexmap-mode.el
@@ -81,16 +81,16 @@ Optionally set RIVERS to non-nil to parse rivers instead."
   (let ((hex (replace-regexp-in-string "//.*" "" hex)))
     (let ((axial-coords (hexmap--extract-axial-coords hex))
 	  (terrain (hexmap--extract-keyword hex "terrain"))
-	  (label (replace-regexp-in-string "\"" "" (hexmap--extract-keyword hex "label")))
 	  (biome (hexmap--extract-keyword hex "biome"))
+	  (label (hexmap--extract-keyword hex "label"))
 	  (features (hexmap--extract-keyword hex "features" t))
 	  (roads (hexmap--extract-roads hex))
 	  (rivers (hexmap--extract-roads hex t)))
       `(:axial-coords ,axial-coords
-		      :biome ,(intern biome)
-		      :terrain ,(intern terrain)
-		      :label ,label
-		      :features ,(mapcar #'intern features)
+		      :biome ,(if biome (intern biome))
+		      :terrain ,(if terrain (intern terrain))
+		      :label ,(if label (replace-regexp-in-string "\"" "" label))
+		      :features ,(if features (mapcar #'intern features))
 		      :roads ,roads
 		      :rivers ,rivers))))
 


### PR DESCRIPTION
Similar to feature painting, but for terrain.

Includes only the blank and hills terrains but can be extended in the future to complete #7.